### PR TITLE
Better handling of snake-ification of mixed input

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -57,15 +57,21 @@ pub trait SnakeCaseExt {
 impl SnakeCaseExt for String {
     fn to_snake_case(&self) -> String {
         let mut s = String::new();
+        let mut was_sep = false;
         if let Some(c) = self.chars().nth(0) {
+            was_sep = SEPARATORS.contains(c);
             s.push(c.to_lowercase().next().unwrap());
         }
         for c in self.chars().skip(1).into_iter() {
             if c.is_lowercase() {
-                s.push(c)
+                was_sep = false;
+                s.push(c);
             } else {
-                s.push('_');
-                if SEPARATORS.contains(c) {
+                if !was_sep {
+                    s.push('_');
+                }
+                was_sep = SEPARATORS.contains(c);
+                if was_sep {
                     continue;
                 } else {
                     s.push(c.to_lowercase().next().unwrap())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,6 +34,24 @@ fn it_works_to_snakecase() {
 }
 
 #[test]
+fn it_works_to_snakecase_mixed() {
+    fn hello_world() -> bool {
+        true
+    }
+    fn hello_world_and_welcome() -> bool {
+        true
+    }
+    assert!(snake!(hello_world)());
+    assert!(snake!(hello_World)());
+    assert!(snake!(helloWorld)());
+    assert!(snake!(HelloWorld)());
+    assert!(snake!(hello_world_and_welcome)());
+    assert!(snake!(hello_world_andWelcome)());
+    assert!(snake!(hello_worldAndWelcome)());
+    assert!(snake!(hello_world_AndWelcome)());
+}
+
+#[test]
 fn it_works_to_pascalcase() {
     #[allow(non_snake_case)]
     fn HelloWorld() -> bool {


### PR DESCRIPTION
Thanks for casey! :-)
I found this issue I was having myself, and made test and patch.
I hope you find it meaningful, though very likely the code could be done better (I am still quite noob in rust).

To be honest, I was asking myself ... would it not be possible to do the actual case conversion with an other crate?
The main selling point of yours, is that ti is done at compile-time. I think, some of the others (run-time ones) around, are more used and have more tests for the case conversion, so it would be cool to make use of that, if possible.
... or is there some technical hindrance for that?

example crates:

* https://github.com/rutrum/convert-case
* https://github.com/withoutboats/heck