### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
       - name: Build
-        run: cargo check --locked
+        run: cargo check --all
       - name: Test
         run: cargo test --all
 


### PR DESCRIPTION
I noticed #8 caused a CI failure. The reason is `--locked` no longer allows that `Cargo.lock` does not exist.